### PR TITLE
post.html - Posts should only include page.image if its defined

### DIFF
--- a/_layouts/basic.html
+++ b/_layouts/basic.html
@@ -15,7 +15,9 @@ body_classes: page-basic
   </div>
 {% endif %}
 
+{% if page.image %}
 <img width="1600" height="900" src="{{ page.image }}"/>
+{% endif %}
 
 <div class="flex flex-col md:flex-row py-6 md:py-12">
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,7 +14,9 @@ layout: default
   </div>
 {% endif %}
 
+{% if page.image %}
 <img width="1600" height="900" src="{{ page.image }}"/>
+{% endif %}
 
 <div class="flex flex-col md:flex-row py-6 md:py-12">
 


### PR DESCRIPTION
Fixes an issue where if you don't define a page image in a post you end up with a large broken image in the generated post.